### PR TITLE
加入Pjax回调函数选项

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -3,9 +3,8 @@
  * 基于 prismjs 的代码语法高亮插件<br />可显示语言类型、行号，有复制功能<br />(请勿与其它同类插件同时启用，以免互相影响)<br />详细说明：<a target="_blank" href="https://www.xcnte.com/archives/523/">https://www.xcnte.com/archives/523/</a>
  * 
  * @package CodePrettify
- * @author Xcnte
- * @version 2.1.5
- * @link https://www.xcnte.com
+ * @author <a href="https://www.xcnte.com">Xcnte</a>,<a href="https://iucky.cn">Wibus</a>
+ * @version 2.1.6
  */
 class CodePrettify_Plugin implements Typecho_Plugin_Interface {
      /**
@@ -45,7 +44,7 @@ class CodePrettify_Plugin implements Typecho_Plugin_Interface {
         $form->addInput($name->addRule('enum', _t('必须选择主题'), $styles));
         $showLineNumber = new Typecho_Widget_Helper_Form_Element_Checkbox('showLineNumber', array('showLineNumber' => _t('显示行号')), array('showLineNumber'), _t('是否在代码左侧显示行号'));
         $form->addInput($showLineNumber);
-        $Pjax = new Typecho_Widget_Helper_Form_Element_Checkbox('Pjax', array('Pjax' => _t('是否启动Pjax')), array('Pjax'), _t('是否启动了Pjax，若启动则插件将会自动加入回调函数'));
+        $Pjax = new Typecho_Widget_Helper_Form_Element_Checkbox('Pjax', array('Pjax' => _t('启动Pjax')), array('Pjax'), _t('是否启动了Pjax'));
         $form->addInput($Pjax);
     }
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -45,6 +45,8 @@ class CodePrettify_Plugin implements Typecho_Plugin_Interface {
         $form->addInput($name->addRule('enum', _t('必须选择主题'), $styles));
         $showLineNumber = new Typecho_Widget_Helper_Form_Element_Checkbox('showLineNumber', array('showLineNumber' => _t('显示行号')), array('showLineNumber'), _t('是否在代码左侧显示行号'));
         $form->addInput($showLineNumber);
+        $Pjax = new Typecho_Widget_Helper_Form_Element_Checkbox('Pjax', array('Pjax' => _t('是否启动Pjax')), array('Pjax'), _t('是否启动了Pjax，若启动则插件将会自动加入回调函数'));
+        $form->addInput($Pjax);
     }
 
     /**
@@ -84,6 +86,29 @@ class CodePrettify_Plugin implements Typecho_Plugin_Interface {
         $jsUrl = Helper::options() -> rootUrl . '/usr/plugins/CodePrettify/static/prism.js';
         $jsUrl_clipboard = Helper::options() -> rootUrl . '/usr/plugins/CodePrettify/static/clipboard.min.js';
         $showLineNumber = Helper::options()->plugin('CodePrettify')->showLineNumber;
+        $Pjax = Helper::options()->plugin('CodePrettify')->Pjax;
+        if ($Pjax){
+            if ($showLineNumber){
+            echo <<<HTML
+            <script>$(document).on("ready pjax:end", function () { 
+                if (typeof Prism !== 'undefined') {
+                    var pres = document.getElementsByTagName('pre');
+                for (var i = 0; i < pres.length; i++){
+                    if (pres[i].getElementsByTagName('code').length > 0)
+                        pres[i].className  = 'line-numbers';}
+                Prism.highlightAll(true,null);}
+            });</script>
+HTML;
+            }else{
+                echo <<<HTML
+                <script>$(document).on("ready pjax:end", function () {
+                     if (typeof Prism !== 'undefined') {
+                        Prism.highlightAll(true,null);}
+                });</script>
+HTML;
+            };
+        }
+
         if ($showLineNumber) {
             echo <<<HTML
 <script type="text/javascript">


### PR DESCRIPTION
直接设置一个是否启动Pjax的选项，这样子的话就免去了加入Pjax回调函数的麻烦，也免去了一大堆人无效的问题

```php
        $Pjax = new Typecho_Widget_Helper_Form_Element_Checkbox('Pjax', array('Pjax' => _t('启动Pjax')), array('Pjax'), _t('是否启动了Pjax'));
        $form->addInput($Pjax);
```
## 浏览站点
浏览站点：https://mix.iucky.cn/

只有一个`CodePrettify`插件，我也没有自己在footer手动加入回调函数

> 我改了下版本号😂